### PR TITLE
change wanit until from published to validated in order to avoid time…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,7 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
+                    <waitUntil>validated</waitUntil>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
change wanit until from published to validated in order to avoid timeout errors because of long publish process of sonatype